### PR TITLE
Fix for Blazor.Streams latest version (0.4.2)

### DIFF
--- a/src/KristofferStrube.Blazor.FileSystem/BaseJSWrapper.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/BaseJSWrapper.cs
@@ -1,36 +1,37 @@
 ﻿using KristofferStrube.Blazor.FileSystem.Extensions;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public abstract class BaseJSWrapper : IAsyncDisposable
+namespace KristofferStrube.Blazor.FileSystem
 {
-    protected readonly Lazy<Task<IJSObjectReference>> helperTask;
-    protected readonly IJSRuntime jSRuntime;
-    protected readonly FileSystemOptions options;
-
-    /// <summary>
-    /// Constructs a wrapper instance for an equivalent JS instance.
-    /// </summary>
-    /// <param name="jSRuntime">An <see cref="IJSRuntime"/> instance.</param>
-    /// <param name="jSReference">A JS reference to an existing JS instance that should be wrapped.</param>
-    internal BaseJSWrapper(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
+    public abstract class BaseJSWrapper : IAsyncDisposable
     {
-        this.options = options;
-        helperTask = new(async () => await jSRuntime.GetHelperAsync(options));
-        JSReference = jSReference;
-        this.jSRuntime = jSRuntime;
-    }
+        protected readonly Lazy<Task<IJSObjectReference>> helperTask;
+        protected readonly IJSRuntime jSRuntime;
+        protected readonly FileSystemOptions options;
 
-    public IJSObjectReference JSReference { get; }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (helperTask.IsValueCreated)
+        /// <summary>
+        /// Constructs a wrapper instance for an equivalent JS instance.
+        /// </summary>
+        /// <param name="jSRuntime">An <see cref="IJSRuntime"/> instance.</param>
+        /// <param name="jSReference">A JS reference to an existing JS instance that should be wrapped.</param>
+        internal BaseJSWrapper(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
         {
-            IJSObjectReference module = await helperTask.Value;
-            await module.DisposeAsync();
+            this.options = options;
+            helperTask = new(async () => await jSRuntime.GetHelperAsync(options));
+            JSReference = jSReference;
+            this.jSRuntime = jSRuntime;
         }
-        GC.SuppressFinalize(this);
+
+        public IJSObjectReference JSReference { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (helperTask.IsValueCreated)
+            {
+                IJSObjectReference module = await helperTask.Value;
+                await module.DisposeAsync();
+            }
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Converters/BlobConverter.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Converters/BlobConverter.cs
@@ -2,17 +2,18 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem.Converters;
-
-internal class BlobConverter : JsonConverter<Blob>
+namespace KristofferStrube.Blazor.FileSystem.Converters
 {
-    public override Blob Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    internal class BlobConverter : JsonConverter<Blob>
     {
-        throw new NotSupportedException("Does not support deserializing Blobs");
-    }
+        public override Blob Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("Does not support deserializing Blobs");
+        }
 
-    public override void Write(Utf8JsonWriter writer, Blob value, JsonSerializerOptions options)
-    {
-        JsonSerializer.Serialize(writer, value.JSReference, options);
+        public override void Write(Utf8JsonWriter writer, Blob value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value.JSReference, options);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/EnumDescriptionConverter.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/EnumDescriptionConverter.cs
@@ -3,43 +3,44 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
+namespace KristofferStrube.Blazor.FileSystem
+{
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning disable CS8603 // Possible null reference return.
 #pragma warning disable CS8604 // Possible null reference argument.
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-internal class EnumDescriptionConverter<T> : JsonConverter<T> where T : IComparable, IFormattable, IConvertible
-{
-    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    internal class EnumDescriptionConverter<T> : JsonConverter<T> where T : IComparable, IFormattable, IConvertible
     {
-        string jsonValue = reader.GetString();
-
-        foreach (FieldInfo? fi in typeToConvert.GetFields())
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            DescriptionAttribute description = (DescriptionAttribute)fi.GetCustomAttribute(typeof(DescriptionAttribute), false);
+            string jsonValue = reader.GetString();
 
-            if (description != null)
+            foreach (FieldInfo? fi in typeToConvert.GetFields())
             {
-                if (description.Description == jsonValue)
+                DescriptionAttribute description = (DescriptionAttribute)fi.GetCustomAttribute(typeof(DescriptionAttribute), false);
+
+                if (description != null)
                 {
-                    return (T)fi.GetValue(null);
+                    if (description.Description == jsonValue)
+                    {
+                        return (T)fi.GetValue(null);
+                    }
                 }
             }
+            throw new JsonException($"string {jsonValue} was not found as a description in the enum {typeToConvert}");
         }
-        throw new JsonException($"string {jsonValue} was not found as a description in the enum {typeToConvert}");
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            FieldInfo fi = value.GetType().GetField(value.ToString());
+
+            DescriptionAttribute description = (DescriptionAttribute)fi.GetCustomAttribute(typeof(DescriptionAttribute), false);
+
+            writer.WriteStringValue(description.Description);
+        }
     }
-
-    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-    {
-        FieldInfo fi = value.GetType().GetField(value.ToString());
-
-        DescriptionAttribute description = (DescriptionAttribute)fi.GetCustomAttribute(typeof(DescriptionAttribute), false);
-
-        writer.WriteStringValue(description.Description);
-    }
-}
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 #pragma warning restore CS8604 // Possible null reference argument.
 #pragma warning restore CS8603 // Possible null reference return.
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+}

--- a/src/KristofferStrube.Blazor.FileSystem/Enums/FileSystemCreateWritableOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Enums/FileSystemCreateWritableOptions.cs
@@ -1,13 +1,14 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemcreatewritableoptions">FileSystemCreateWritableOptions browser specs</see>
-/// </summary>
-public class FileSystemCreateWritableOptions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [JsonPropertyName("keepExistingData")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool KeepExistingData { get; set; }
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemcreatewritableoptions">FileSystemCreateWritableOptions browser specs</see>
+    /// </summary>
+    public class FileSystemCreateWritableOptions
+    {
+        [JsonPropertyName("keepExistingData")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool KeepExistingData { get; set; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Enums/FileSystemHandleKind.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Enums/FileSystemHandleKind.cs
@@ -1,16 +1,17 @@
 ﻿using System.ComponentModel;
 using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#enumdef-filesystemhandlekind">FileSystemHandleKind browser specs</see>
-/// </summary>
-[JsonConverter(typeof(EnumDescriptionConverter<FileSystemHandleKind>))]
-public enum FileSystemHandleKind
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [Description("file")]
-    File,
-    [Description("directory")]
-    Directory,
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#enumdef-filesystemhandlekind">FileSystemHandleKind browser specs</see>
+    /// </summary>
+    [JsonConverter(typeof(EnumDescriptionConverter<FileSystemHandleKind>))]
+    public enum FileSystemHandleKind
+    {
+        [Description("file")]
+        File,
+        [Description("directory")]
+        Directory,
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Enums/WriteCommandType.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Enums/WriteCommandType.cs
@@ -1,18 +1,19 @@
 ﻿using System.ComponentModel;
 using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#enumdef-writecommandtype">WriteCommandType browser specs</see>
-/// </summary>
-[JsonConverter(typeof(EnumDescriptionConverter<WriteCommandType>))]
-public enum WriteCommandType
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [Description("write")]
-    Write,
-    [Description("seek")]
-    Seek,
-    [Description("truncate")]
-    Truncate,
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#enumdef-writecommandtype">WriteCommandType browser specs</see>
+    /// </summary>
+    [JsonConverter(typeof(EnumDescriptionConverter<WriteCommandType>))]
+    public enum WriteCommandType
+    {
+        [Description("write")]
+        Write,
+        [Description("seek")]
+        Seek,
+        [Description("truncate")]
+        Truncate,
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Extensions/IJSRuntimeExtensions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Extensions/IJSRuntimeExtensions.cs
@@ -1,26 +1,27 @@
 ﻿using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem.Extensions;
-
-internal static class IJSRuntimeExtensions
+namespace KristofferStrube.Blazor.FileSystem.Extensions
 {
-    internal static async Task<IJSObjectReference> GetHelperAsync(this IJSRuntime jSRuntime, FileSystemOptions options)
+    internal static class IJSRuntimeExtensions
     {
-        return await GetHelperAsync<IJSObjectReference>(jSRuntime, options);
-    }
+        internal static async Task<IJSObjectReference> GetHelperAsync(this IJSRuntime jSRuntime, FileSystemOptions options)
+        {
+            return await GetHelperAsync<IJSObjectReference>(jSRuntime, options);
+        }
 
-    internal static async Task<IJSInProcessObjectReference> GetInProcessHelperAsync(this IJSRuntime jSRuntime, FileSystemOptions options)
-    {
-        return await GetHelperAsync<IJSInProcessObjectReference>(jSRuntime, options);
-    }
+        internal static async Task<IJSInProcessObjectReference> GetInProcessHelperAsync(this IJSRuntime jSRuntime, FileSystemOptions options)
+        {
+            return await GetHelperAsync<IJSInProcessObjectReference>(jSRuntime, options);
+        }
 
-    private static async Task<T> GetHelperAsync<T>(IJSRuntime jSRuntime, FileSystemOptions options)
-    {
-        return await jSRuntime.InvokeAsync<T>("import", GetScriptPath(options));
-    }
+        private static async Task<T> GetHelperAsync<T>(IJSRuntime jSRuntime, FileSystemOptions options)
+        {
+            return await jSRuntime.InvokeAsync<T>("import", GetScriptPath(options));
+        }
 
-    private static string GetScriptPath(FileSystemOptions options)
-    {
-        return options.FullScriptPath;
+        private static string GetScriptPath(FileSystemOptions options)
+        {
+            return options.FullScriptPath;
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Extensions/IServiceCollectionExtensions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Extensions/IServiceCollectionExtensions.cs
@@ -1,45 +1,46 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public static class IServiceCollectionExtensions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public static IServiceCollection AddStorageManagerService(this IServiceCollection serviceCollection)
+    public static class IServiceCollectionExtensions
     {
-        return AddStorageManagerService(serviceCollection, null);
+        public static IServiceCollection AddStorageManagerService(this IServiceCollection serviceCollection)
+        {
+            return AddStorageManagerService(serviceCollection, null);
+        }
+
+        public static IServiceCollection AddStorageManagerService(this IServiceCollection serviceCollection, Action<FileSystemOptions>? configure)
+        {
+            ConfigureFsOptions(serviceCollection, configure);
+
+            return serviceCollection.AddScoped<IStorageManagerService, StorageManagerService>();
+        }
+
+        public static IServiceCollection AddStorageManagerServiceInProcess(this IServiceCollection serviceCollection)
+        {
+            return AddStorageManagerServiceInProcess(serviceCollection, null);
+        }
+
+        public static IServiceCollection AddStorageManagerServiceInProcess(this IServiceCollection serviceCollection, Action<FileSystemOptions>? configure)
+        {
+            ConfigureFsOptions(serviceCollection, configure);
+
+            return serviceCollection
+                .AddScoped<IStorageManagerServiceInProcess, StorageManagerServiceInProcess>()
+                .AddScoped(sp =>
+                {
+                    IStorageManagerServiceInProcess service = sp.GetRequiredService<IStorageManagerServiceInProcess>();
+                    return (IStorageManagerService)service;
+                });
+        }
+
+        private static void ConfigureFsOptions(IServiceCollection services, Action<FileSystemOptions>? configure)
+        {
+            if (configure is null) { return; }
+
+            services.Configure(configure);
+            configure(FileSystemOptions.DefaultInstance);
+        }
+
     }
-
-    public static IServiceCollection AddStorageManagerService(this IServiceCollection serviceCollection, Action<FileSystemOptions>? configure)
-    {
-        ConfigureFsOptions(serviceCollection, configure);
-
-        return serviceCollection.AddScoped<IStorageManagerService, StorageManagerService>();
-    }
-
-    public static IServiceCollection AddStorageManagerServiceInProcess(this IServiceCollection serviceCollection)
-    {
-        return AddStorageManagerServiceInProcess(serviceCollection, null);
-    }
-
-    public static IServiceCollection AddStorageManagerServiceInProcess(this IServiceCollection serviceCollection, Action<FileSystemOptions>? configure)
-    {
-        ConfigureFsOptions(serviceCollection, configure);
-
-        return serviceCollection
-            .AddScoped<IStorageManagerServiceInProcess, StorageManagerServiceInProcess>()
-            .AddScoped(sp =>
-            {
-                IStorageManagerServiceInProcess service = sp.GetRequiredService<IStorageManagerServiceInProcess>();
-                return (IStorageManagerService)service;
-            });
-    }
-
-    private static void ConfigureFsOptions(IServiceCollection services, Action<FileSystemOptions>? configure)
-    {
-        if (configure is null) { return; }
-
-        services.Configure(configure);
-        configure(FileSystemOptions.DefaultInstance);
-    }
-
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemDirectoryHandle.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemDirectoryHandle.InProcess.cs
@@ -1,70 +1,71 @@
 ﻿using KristofferStrube.Blazor.FileSystem.Extensions;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemdirectoryhandle">FileSystemDirectoryHandle browser specs</see>
-/// </summary>
-public class FileSystemDirectoryHandleInProcess : FileSystemDirectoryHandle, IFileSystemHandleInProcess
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public new IJSInProcessObjectReference JSReference;
-    protected readonly IJSInProcessObjectReference inProcessHelper;
-
-    public static async Task<FileSystemDirectoryHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemdirectoryhandle">FileSystemDirectoryHandle browser specs</see>
+    /// </summary>
+    public class FileSystemDirectoryHandleInProcess : FileSystemDirectoryHandle, IFileSystemHandleInProcess
     {
-        return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public new IJSInProcessObjectReference JSReference;
+        protected readonly IJSInProcessObjectReference inProcessHelper;
 
-    public static async Task<FileSystemDirectoryHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
-    {
-        IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
-        return new FileSystemDirectoryHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
-    }
+        public static async Task<FileSystemDirectoryHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+        {
+            return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    internal FileSystemDirectoryHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
-    {
-        this.inProcessHelper = inProcessHelper;
-        JSReference = jSReference;
-    }
+        public static async Task<FileSystemDirectoryHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
+        {
+            IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
+            return new FileSystemDirectoryHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
+        }
 
-    public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
+        internal FileSystemDirectoryHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
+        {
+            this.inProcessHelper = inProcessHelper;
+            JSReference = jSReference;
+        }
 
-    public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
+        public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
 
-    public new async Task<IFileSystemHandleInProcess[]> ValuesAsync()
-    {
-        IJSObjectReference helper = await helperTask.Value;
-        IJSObjectReference jSValues = await JSReference.InvokeAsync<IJSObjectReference>("values");
-        IJSObjectReference jSEntries = await helper.InvokeAsync<IJSObjectReference>("arrayFrom", jSValues);
-        int length = await helper.InvokeAsync<int>("size", jSEntries);
-        return await Task.WhenAll(
-            Enumerable
-                .Range(0, length)
-                .Select<int, Task<IFileSystemHandleInProcess>>(async i =>
-                {
-                    var fileSystemHandle = await FileSystemHandleInProcess.CreateAsync(
-                        jSRuntime,
-                        await jSEntries.InvokeAsync<IJSInProcessObjectReference>("at", i),
-                        options);
-                    return (fileSystemHandle.Kind is FileSystemHandleKind.File)
-                        ? await FileSystemFileHandleInProcess.CreateAsync(jSRuntime, fileSystemHandle.JSReference, options)
-                        : await FileSystemDirectoryHandleInProcess.CreateAsync(jSRuntime, fileSystemHandle.JSReference, options);
-                }
-                )
-                .ToArray()
-        );
-    }
+        public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
 
-    public new async Task<FileSystemFileHandleInProcess> GetFileHandleAsync(string name, FileSystemGetFileOptions? options = null)
-    {
-        IJSInProcessObjectReference jSFileSystemFileHandle = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getFileHandle", name, options);
-        return new FileSystemFileHandleInProcess(jSRuntime, inProcessHelper, jSFileSystemFileHandle, this.options);
-    }
+        public new async Task<IFileSystemHandleInProcess[]> ValuesAsync()
+        {
+            IJSObjectReference helper = await helperTask.Value;
+            IJSObjectReference jSValues = await JSReference.InvokeAsync<IJSObjectReference>("values");
+            IJSObjectReference jSEntries = await helper.InvokeAsync<IJSObjectReference>("arrayFrom", jSValues);
+            int length = await helper.InvokeAsync<int>("size", jSEntries);
+            return await Task.WhenAll(
+                Enumerable
+                    .Range(0, length)
+                    .Select<int, Task<IFileSystemHandleInProcess>>(async i =>
+                        {
+                            var fileSystemHandle = await FileSystemHandleInProcess.CreateAsync(
+                                jSRuntime,
+                                await jSEntries.InvokeAsync<IJSInProcessObjectReference>("at", i),
+                                options);
+                            return (fileSystemHandle.Kind is FileSystemHandleKind.File)
+                                ? await FileSystemFileHandleInProcess.CreateAsync(jSRuntime, fileSystemHandle.JSReference, options)
+                                : await FileSystemDirectoryHandleInProcess.CreateAsync(jSRuntime, fileSystemHandle.JSReference, options);
+                        }
+                    )
+                    .ToArray()
+            );
+        }
 
-    public new async Task<FileSystemDirectoryHandleInProcess> GetDirectoryHandleAsync(string name, FileSystemGetDirectoryOptions? options = null)
-    {
-        IJSInProcessObjectReference jSFileSystemDirectoryHandle = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getDirectoryHandle", name, options);
-        return new FileSystemDirectoryHandleInProcess(jSRuntime, inProcessHelper, jSFileSystemDirectoryHandle, this.options);
+        public new async Task<FileSystemFileHandleInProcess> GetFileHandleAsync(string name, FileSystemGetFileOptions? options = null)
+        {
+            IJSInProcessObjectReference jSFileSystemFileHandle = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getFileHandle", name, options);
+            return new FileSystemFileHandleInProcess(jSRuntime, inProcessHelper, jSFileSystemFileHandle, this.options);
+        }
+
+        public new async Task<FileSystemDirectoryHandleInProcess> GetDirectoryHandleAsync(string name, FileSystemGetDirectoryOptions? options = null)
+        {
+            IJSInProcessObjectReference jSFileSystemDirectoryHandle = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getDirectoryHandle", name, options);
+            return new FileSystemDirectoryHandleInProcess(jSRuntime, inProcessHelper, jSFileSystemDirectoryHandle, this.options);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemDirectoryHandle.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemDirectoryHandle.cs
@@ -1,67 +1,68 @@
 ﻿using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemdirectoryhandle">FileSystemDirectoryHandle browser specs</see>
-/// </summary>
-public class FileSystemDirectoryHandle : FileSystemHandle
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public static new FileSystemDirectoryHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemdirectoryhandle">FileSystemDirectoryHandle browser specs</see>
+    /// </summary>
+    public class FileSystemDirectoryHandle : FileSystemHandle
     {
-        return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public static new FileSystemDirectoryHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+        {
+            return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    public static new FileSystemDirectoryHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
-    {
-        return new(jSRuntime, jSReference, options);
-    }
+        public static new FileSystemDirectoryHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
+        {
+            return new(jSRuntime, jSReference, options);
+        }
 
-    internal FileSystemDirectoryHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
+        internal FileSystemDirectoryHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
 
-    public async Task<IFileSystemHandle[]> ValuesAsync()
-    {
-        IJSObjectReference helper = await helperTask.Value;
-        IJSObjectReference jSValues = await JSReference.InvokeAsync<IJSObjectReference>("values");
-        IJSObjectReference jSEntries = await helper.InvokeAsync<IJSObjectReference>("arrayFrom", jSValues);
-        int length = await helper.InvokeAsync<int>("size", jSEntries);
-        return await Task.WhenAll(
-            Enumerable
-                .Range(0, length)
-                .Select<int, Task<FileSystemHandle>>(async i =>
-                    {
-                        var fileSystemHandle = new FileSystemHandle(
-                            jSRuntime,
-                            await jSEntries.InvokeAsync<IJSObjectReference>("at", i),
-                            options);
-                        return (await fileSystemHandle.GetKindAsync() is FileSystemHandleKind.File)
-                            ? FileSystemFileHandle.Create(jSRuntime, fileSystemHandle.JSReference, options)
-                            : FileSystemDirectoryHandle.Create(jSRuntime, fileSystemHandle.JSReference, options);
-                    }
-                )
-                .ToArray()
-        );
-    }
+        public async Task<IFileSystemHandle[]> ValuesAsync()
+        {
+            IJSObjectReference helper = await helperTask.Value;
+            IJSObjectReference jSValues = await JSReference.InvokeAsync<IJSObjectReference>("values");
+            IJSObjectReference jSEntries = await helper.InvokeAsync<IJSObjectReference>("arrayFrom", jSValues);
+            int length = await helper.InvokeAsync<int>("size", jSEntries);
+            return await Task.WhenAll(
+                Enumerable
+                    .Range(0, length)
+                    .Select<int, Task<FileSystemHandle>>(async i =>
+                        {
+                            var fileSystemHandle = new FileSystemHandle(
+                                jSRuntime,
+                                await jSEntries.InvokeAsync<IJSObjectReference>("at", i),
+                                options);
+                            return (await fileSystemHandle.GetKindAsync() is FileSystemHandleKind.File)
+                                ? FileSystemFileHandle.Create(jSRuntime, fileSystemHandle.JSReference, options)
+                                : FileSystemDirectoryHandle.Create(jSRuntime, fileSystemHandle.JSReference, options);
+                        }
+                    )
+                    .ToArray()
+            );
+        }
 
-    public async Task<FileSystemFileHandle> GetFileHandleAsync(string name, FileSystemGetFileOptions? options = null)
-    {
-        IJSObjectReference jSFileSystemFileHandle = await JSReference.InvokeAsync<IJSObjectReference>("getFileHandle", name, options);
-        return new FileSystemFileHandle(jSRuntime, jSFileSystemFileHandle, this.options);
-    }
+        public async Task<FileSystemFileHandle> GetFileHandleAsync(string name, FileSystemGetFileOptions? options = null)
+        {
+            IJSObjectReference jSFileSystemFileHandle = await JSReference.InvokeAsync<IJSObjectReference>("getFileHandle", name, options);
+            return new FileSystemFileHandle(jSRuntime, jSFileSystemFileHandle, this.options);
+        }
 
-    public async Task<FileSystemDirectoryHandle> GetDirectoryHandleAsync(string name, FileSystemGetDirectoryOptions? options = null)
-    {
-        IJSObjectReference jSFileSystemDirectoryHandle = await JSReference.InvokeAsync<IJSObjectReference>("getDirectoryHandle", name, options);
-        return new FileSystemDirectoryHandle(jSRuntime, jSFileSystemDirectoryHandle, this.options);
-    }
+        public async Task<FileSystemDirectoryHandle> GetDirectoryHandleAsync(string name, FileSystemGetDirectoryOptions? options = null)
+        {
+            IJSObjectReference jSFileSystemDirectoryHandle = await JSReference.InvokeAsync<IJSObjectReference>("getDirectoryHandle", name, options);
+            return new FileSystemDirectoryHandle(jSRuntime, jSFileSystemDirectoryHandle, this.options);
+        }
 
-    public async Task RemoveEntryAsync(string name, FileSystemRemoveOptions? options = null)
-    {
-        await JSReference.InvokeVoidAsync("removeEntry", name, options);
-    }
+        public async Task RemoveEntryAsync(string name, FileSystemRemoveOptions? options = null)
+        {
+            await JSReference.InvokeVoidAsync("removeEntry", name, options);
+        }
 
-    public async Task<string[]?> ResolveAsync(IFileSystemHandle possibleDescendant)
-    {
-        return await JSReference.InvokeAsync<string[]?>("resolve", possibleDescendant.JSReference);
+        public async Task<string[]?> ResolveAsync(IFileSystemHandle possibleDescendant)
+        {
+            return await JSReference.InvokeAsync<string[]?>("resolve", possibleDescendant.JSReference);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemFileHandle.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemFileHandle.InProcess.cs
@@ -2,46 +2,47 @@
 using KristofferStrube.Blazor.FileSystem.Extensions;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemfilehandle">FileSystemFileHandle browser specs</see>
-/// </summary>
-public class FileSystemFileHandleInProcess : FileSystemFileHandle, IFileSystemHandleInProcess
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public new IJSInProcessObjectReference JSReference;
-    protected readonly IJSInProcessObjectReference inProcessHelper;
-
-    public static async Task<FileSystemFileHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemfilehandle">FileSystemFileHandle browser specs</see>
+    /// </summary>
+    public class FileSystemFileHandleInProcess : FileSystemFileHandle, IFileSystemHandleInProcess
     {
-        return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public new IJSInProcessObjectReference JSReference;
+        protected readonly IJSInProcessObjectReference inProcessHelper;
 
-    public static async Task<FileSystemFileHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
-    {
-        IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
-        return new FileSystemFileHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
-    }
+        public static async Task<FileSystemFileHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+        {
+            return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    internal FileSystemFileHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
-    {
-        this.inProcessHelper = inProcessHelper;
-        JSReference = jSReference;
-    }
+        public static async Task<FileSystemFileHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
+        {
+            IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
+            return new FileSystemFileHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
+        }
 
-    public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
+        internal FileSystemFileHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
+        {
+            this.inProcessHelper = inProcessHelper;
+            JSReference = jSReference;
+        }
 
-    public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
+        public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
 
-    public new async Task<FileInProcess> GetFileAsync()
-    {
-        IJSInProcessObjectReference jSFile = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getFile");
-        return await FileInProcess.CreateAsync(jSRuntime, jSFile);
-    }
+        public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
 
-    public new async Task<FileSystemWritableFileStreamInProcess> CreateWritableAsync(FileSystemCreateWritableOptions? fileSystemCreateWritableOptions = null)
-    {
-        IJSInProcessObjectReference jSFileSystemWritableFileStream = await JSReference.InvokeAsync<IJSInProcessObjectReference>("createWritable", fileSystemCreateWritableOptions);
-        return new FileSystemWritableFileStreamInProcess(jSRuntime, inProcessHelper, jSFileSystemWritableFileStream);
+        public new async Task<FileInProcess> GetFileAsync()
+        {
+            IJSInProcessObjectReference jSFile = await JSReference.InvokeAsync<IJSInProcessObjectReference>("getFile");
+            return await FileInProcess.CreateAsync(jSRuntime, jSFile);
+        }
+
+        public new async Task<FileSystemWritableFileStreamInProcess> CreateWritableAsync(FileSystemCreateWritableOptions? fileSystemCreateWritableOptions = null)
+        {
+            IJSInProcessObjectReference jSFileSystemWritableFileStream = await JSReference.InvokeAsync<IJSInProcessObjectReference>("createWritable", fileSystemCreateWritableOptions);
+            return new FileSystemWritableFileStreamInProcess(jSRuntime, inProcessHelper, jSFileSystemWritableFileStream);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemFileHandle.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemFileHandle.cs
@@ -1,33 +1,34 @@
 ﻿using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemfilehandle">FileSystemFileHandle browser specs</see>
-/// </summary>
-public class FileSystemFileHandle : FileSystemHandle
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public static new FileSystemFileHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemfilehandle">FileSystemFileHandle browser specs</see>
+    /// </summary>
+    public class FileSystemFileHandle : FileSystemHandle
     {
-        return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public static new FileSystemFileHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+        {
+            return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    public static new FileSystemFileHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
-    {
-        return new(jSRuntime, jSReference, options);
-    }
+        public static new FileSystemFileHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
+        {
+            return new(jSRuntime, jSReference, options);
+        }
 
-    internal FileSystemFileHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
+        internal FileSystemFileHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
 
-    public async Task<FileAPI.File> GetFileAsync()
-    {
-        IJSObjectReference jSFile = await JSReference.InvokeAsync<IJSObjectReference>("getFile");
-        return FileAPI.File.Create(jSRuntime, jSFile);
-    }
+        public async Task<FileAPI.File> GetFileAsync()
+        {
+            IJSObjectReference jSFile = await JSReference.InvokeAsync<IJSObjectReference>("getFile");
+            return FileAPI.File.Create(jSRuntime, jSFile);
+        }
 
-    public async Task<FileSystemWritableFileStream> CreateWritableAsync(FileSystemCreateWritableOptions? fileSystemCreateWritableOptions = null)
-    {
-        IJSObjectReference jSFileSystemWritableFileStream = await JSReference.InvokeAsync<IJSObjectReference>("createWritable", fileSystemCreateWritableOptions);
-        return await FileSystemWritableFileStream.CreateAsync(jSRuntime, jSFileSystemWritableFileStream);
+        public async Task<FileSystemWritableFileStream> CreateWritableAsync(FileSystemCreateWritableOptions? fileSystemCreateWritableOptions = null)
+        {
+            IJSObjectReference jSFileSystemWritableFileStream = await JSReference.InvokeAsync<IJSObjectReference>("createWritable", fileSystemCreateWritableOptions);
+            return await FileSystemWritableFileStream.CreateAsync(jSRuntime, jSFileSystemWritableFileStream);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemHandle.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemHandle.InProcess.cs
@@ -1,34 +1,35 @@
 ﻿using KristofferStrube.Blazor.FileSystem.Extensions;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemhandle">FileSystemHandle browser specs</see>
-/// </summary>
-public class FileSystemHandleInProcess : FileSystemHandle, IFileSystemHandleInProcess
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public new IJSInProcessObjectReference JSReference;
-    protected readonly IJSInProcessObjectReference inProcessHelper;
-
-    public static async Task<FileSystemHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemhandle">FileSystemHandle browser specs</see>
+    /// </summary>
+    public class FileSystemHandleInProcess : FileSystemHandle, IFileSystemHandleInProcess
     {
-        return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        public new IJSInProcessObjectReference JSReference;
+        protected readonly IJSInProcessObjectReference inProcessHelper;
+
+        public static async Task<FileSystemHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+        {
+            return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
+
+        public static async Task<FileSystemHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
+        {
+            IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
+            return new FileSystemHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
+        }
+
+        internal FileSystemHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
+        {
+            this.inProcessHelper = inProcessHelper;
+            JSReference = jSReference;
+        }
+
+        public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
+
+        public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
     }
-
-    public static async Task<FileSystemHandleInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
-    {
-        IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
-        return new FileSystemHandleInProcess(jSRuntime, inProcessHelper, jSReference, options);
-    }
-
-    internal FileSystemHandleInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options)
-    {
-        this.inProcessHelper = inProcessHelper;
-        JSReference = jSReference;
-    }
-
-    public FileSystemHandleKind Kind => inProcessHelper.Invoke<FileSystemHandleKind>("getAttribute", JSReference, "kind");
-
-    public string Name => inProcessHelper.Invoke<string>("getAttribute", JSReference, "name");
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemHandle.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemHandle.cs
@@ -1,38 +1,39 @@
 ﻿using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemhandle">FileSystemHandle browser specs</see>
-/// </summary>
-public class FileSystemHandle : BaseJSWrapper, IFileSystemHandle
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public static FileSystemHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemhandle">FileSystemHandle browser specs</see>
+    /// </summary>
+    public class FileSystemHandle : BaseJSWrapper, IFileSystemHandle
     {
-        return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public static FileSystemHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+        {
+            return Create(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    public static FileSystemHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
-    {
-        return new(jSRuntime, jSReference, options);
-    }
+        public static FileSystemHandle Create(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options)
+        {
+            return new(jSRuntime, jSReference, options);
+        }
 
-    internal FileSystemHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
+        internal FileSystemHandle(IJSRuntime jSRuntime, IJSObjectReference jSReference, FileSystemOptions options) : base(jSRuntime, jSReference, options) { }
 
-    public async Task<FileSystemHandleKind> GetKindAsync()
-    {
-        IJSObjectReference helper = await helperTask.Value;
-        return await helper.InvokeAsync<FileSystemHandleKind>("getAttribute", JSReference, "kind");
-    }
+        public async Task<FileSystemHandleKind> GetKindAsync()
+        {
+            IJSObjectReference helper = await helperTask.Value;
+            return await helper.InvokeAsync<FileSystemHandleKind>("getAttribute", JSReference, "kind");
+        }
 
-    public async Task<string> GetNameAsync()
-    {
-        IJSObjectReference helper = await helperTask.Value;
-        return await helper.InvokeAsync<string>("getAttribute", JSReference, "name");
-    }
+        public async Task<string> GetNameAsync()
+        {
+            IJSObjectReference helper = await helperTask.Value;
+            return await helper.InvokeAsync<string>("getAttribute", JSReference, "name");
+        }
 
-    public async Task<bool> IsSameEntryAsync(IFileSystemHandle other)
-    {
-        return await JSReference.InvokeAsync<bool>("isSameEntry", other.JSReference);
+        public async Task<bool> IsSameEntryAsync(IFileSystemHandle other)
+        {
+            return await JSReference.InvokeAsync<bool>("isSameEntry", other.JSReference);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.InProcess.cs
@@ -1,30 +1,31 @@
 ﻿using KristofferStrube.Blazor.FileSystem.Extensions;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemwritablefilestream">FileSystemWritableFileStream browser specs</see>
-/// </summary>
-public class FileSystemWritableFileStreamInProcess : FileSystemWritableFileStream
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public new IJSInProcessObjectReference JSReference;
-    protected readonly IJSInProcessObjectReference inProcessHelper;
-
-    public static async Task<FileSystemWritableFileStreamInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#filesystemwritablefilestream">FileSystemWritableFileStream browser specs</see>
+    /// </summary>
+    public class FileSystemWritableFileStreamInProcess : FileSystemWritableFileStream
     {
-        return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
-    }
+        public new IJSInProcessObjectReference JSReference;
+        protected readonly IJSInProcessObjectReference inProcessHelper;
 
-    public static async Task<FileSystemWritableFileStreamInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
-    {
-        IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
-        return new FileSystemWritableFileStreamInProcess(jSRuntime, inProcessHelper, jSReference);
-    }
+        public static async Task<FileSystemWritableFileStreamInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+        {
+            return await CreateAsync(jSRuntime, jSReference, FileSystemOptions.DefaultInstance);
+        }
 
-    internal FileSystemWritableFileStreamInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference) : base(jSRuntime, jSReference)
-    {
-        this.inProcessHelper = inProcessHelper;
-        JSReference = jSReference;
+        public static async Task<FileSystemWritableFileStreamInProcess> CreateAsync(IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference, FileSystemOptions options)
+        {
+            IJSInProcessObjectReference inProcessHelper = await jSRuntime.GetInProcessHelperAsync(options);
+            return new FileSystemWritableFileStreamInProcess(jSRuntime, inProcessHelper, jSReference);
+        }
+
+        internal FileSystemWritableFileStreamInProcess(IJSRuntime jSRuntime, IJSInProcessObjectReference inProcessHelper, IJSInProcessObjectReference jSReference) : base(jSRuntime, jSReference)
+        {
+            this.inProcessHelper = inProcessHelper;
+            JSReference = jSReference;
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.cs
@@ -30,7 +30,7 @@ public class FileSystemWritableFileStream : WritableStream
         return Task.FromResult(new FileSystemWritableFileStream(jSRuntime, jSReference));
     }
 
-    protected FileSystemWritableFileStream(IJSRuntime jSRuntime, IJSObjectReference jSReference) : base(jSRuntime, jSReference)
+    protected FileSystemWritableFileStream(IJSRuntime jSRuntime, IJSObjectReference jSReference) : base(jSRuntime, jSReference, new())
     {
         fileSystemHelperTask = new(() => jSRuntime.GetHelperAsync(FileSystemOptions.DefaultInstance));
     }

--- a/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/FileSystemWritableFileStream.cs
@@ -3,81 +3,82 @@ using KristofferStrube.Blazor.FileSystem.Extensions;
 using KristofferStrube.Blazor.Streams;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#filesystemwritablefilestream">FileSystemWritableFileStream browser specs</see>
-/// </summary>
-public class FileSystemWritableFileStream : WritableStream
+namespace KristofferStrube.Blazor.FileSystem
 {
     /// <summary>
-    /// A lazily evaluated task that gives access to helper methods for the File System API.
+    /// <see href="https://fs.spec.whatwg.org/#filesystemwritablefilestream">FileSystemWritableFileStream browser specs</see>
     /// </summary>
-    protected readonly Lazy<Task<IJSObjectReference>> fileSystemHelperTask;
-
-    public override bool CanSeek => true;
-
-    public override long Position { get; set; }
-
-    [Obsolete("This will be removed in the next major release as all creator methods should be asynchronous for uniformity. Use CreateAsync instead.")]
-    public static new FileSystemWritableFileStream Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+    public class FileSystemWritableFileStream : WritableStream
     {
-        return new FileSystemWritableFileStream(jSRuntime, jSReference);
-    }
+        /// <summary>
+        /// A lazily evaluated task that gives access to helper methods for the File System API.
+        /// </summary>
+        protected readonly Lazy<Task<IJSObjectReference>> fileSystemHelperTask;
 
-    public static new Task<FileSystemWritableFileStream> CreateAsync(IJSRuntime jSRuntime, IJSObjectReference jSReference)
-    {
-        return Task.FromResult(new FileSystemWritableFileStream(jSRuntime, jSReference));
-    }
+        public override bool CanSeek => true;
 
-    protected FileSystemWritableFileStream(IJSRuntime jSRuntime, IJSObjectReference jSReference) : base(jSRuntime, jSReference, new())
-    {
-        fileSystemHelperTask = new(() => jSRuntime.GetHelperAsync(FileSystemOptions.DefaultInstance));
-    }
+        public override long Position { get; set; }
 
-    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
-    {
-        await JSReference.InvokeVoidAsync("write", buffer.ToArray());
-    }
+        [Obsolete("This will be removed in the next major release as all creator methods should be asynchronous for uniformity. Use CreateAsync instead.")]
+        public static new FileSystemWritableFileStream Create(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+        {
+            return new FileSystemWritableFileStream(jSRuntime, jSReference);
+        }
 
-    public async Task WriteAsync(string data)
-    {
-        await JSReference.InvokeVoidAsync("write", data);
-    }
+        public static new Task<FileSystemWritableFileStream> CreateAsync(IJSRuntime jSRuntime, IJSObjectReference jSReference)
+        {
+            return Task.FromResult(new FileSystemWritableFileStream(jSRuntime, jSReference));
+        }
 
-    public async Task WriteAsync(byte[] data)
-    {
-        await JSReference.InvokeVoidAsync("write", data);
-    }
+        protected FileSystemWritableFileStream(IJSRuntime jSRuntime, IJSObjectReference jSReference) : base(jSRuntime, jSReference, new())
+        {
+            fileSystemHelperTask = new(() => jSRuntime.GetHelperAsync(FileSystemOptions.DefaultInstance));
+        }
 
-    public async Task WriteAsync(Blob data)
-    {
-        await JSReference.InvokeVoidAsync("write", data.JSReference);
-    }
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await JSReference.InvokeVoidAsync("write", buffer.ToArray());
+        }
 
-    public async Task WriteAsync(BlobWriteParams data)
-    {
-        await JSReference.InvokeVoidAsync("write", data);
-    }
+        public async Task WriteAsync(string data)
+        {
+            await JSReference.InvokeVoidAsync("write", data);
+        }
 
-    public async Task WriteAsync(StringWriteParams data)
-    {
-        await JSReference.InvokeVoidAsync("write", data);
-    }
+        public async Task WriteAsync(byte[] data)
+        {
+            await JSReference.InvokeVoidAsync("write", data);
+        }
 
-    public async Task WriteAsync(ByteArrayWriteParams data)
-    {
-        await JSReference.InvokeVoidAsync("write", data);
-    }
+        public async Task WriteAsync(Blob data)
+        {
+            await JSReference.InvokeVoidAsync("write", data.JSReference);
+        }
 
-    public async Task SeekAsync(ulong position)
-    {
-        Position = (long)position;
-        await JSReference.InvokeVoidAsync("seek", position);
-    }
+        public async Task WriteAsync(BlobWriteParams data)
+        {
+            await JSReference.InvokeVoidAsync("write", data);
+        }
 
-    public async Task TruncateAsync(ulong size)
-    {
-        await JSReference.InvokeVoidAsync("truncate", size);
+        public async Task WriteAsync(StringWriteParams data)
+        {
+            await JSReference.InvokeVoidAsync("write", data);
+        }
+
+        public async Task WriteAsync(ByteArrayWriteParams data)
+        {
+            await JSReference.InvokeVoidAsync("write", data);
+        }
+
+        public async Task SeekAsync(ulong position)
+        {
+            Position = (long)position;
+            await JSReference.InvokeVoidAsync("seek", position);
+        }
+
+        public async Task TruncateAsync(ulong size)
+        {
+            await JSReference.InvokeVoidAsync("truncate", size);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/IFileSystemHandle.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/IFileSystemHandle.InProcess.cs
@@ -1,7 +1,8 @@
-﻿namespace KristofferStrube.Blazor.FileSystem;
-
-public interface IFileSystemHandleInProcess : IFileSystemHandle
+﻿namespace KristofferStrube.Blazor.FileSystem
 {
-    FileSystemHandleKind Kind { get; }
-    string Name { get; }
+    public interface IFileSystemHandleInProcess : IFileSystemHandle
+    {
+        FileSystemHandleKind Kind { get; }
+        string Name { get; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/IFileSystemHandle.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/IFileSystemHandle.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public interface IFileSystemHandle
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public IJSObjectReference JSReference { get; }
-    Task<FileSystemHandleKind> GetKindAsync();
-    Task<string> GetNameAsync();
-    Task<bool> IsSameEntryAsync(IFileSystemHandle other);
+    public interface IFileSystemHandle
+    {
+        public IJSObjectReference JSReference { get; }
+        Task<FileSystemHandleKind> GetKindAsync();
+        Task<string> GetNameAsync();
+        Task<bool> IsSameEntryAsync(IFileSystemHandle other);
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/IStorageManagerService.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/IStorageManagerService.InProcess.cs
@@ -1,6 +1,7 @@
-﻿namespace KristofferStrube.Blazor.FileSystem;
-
-public interface IStorageManagerServiceInProcess : IStorageManagerService
+﻿namespace KristofferStrube.Blazor.FileSystem
 {
-    new Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync();
+    public interface IStorageManagerServiceInProcess : IStorageManagerService
+    {
+        new Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync();
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/IStorageManagerService.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/IStorageManagerService.cs
@@ -1,6 +1,7 @@
-﻿namespace KristofferStrube.Blazor.FileSystem;
-
-public interface IStorageManagerService
+﻿namespace KristofferStrube.Blazor.FileSystem
 {
-    Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync();
+    public interface IStorageManagerService
+    {
+        Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync();
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/KristofferStrube.Blazor.FileSystem.csproj
+++ b/src/KristofferStrube.Blazor.FileSystem/KristofferStrube.Blazor.FileSystem.csproj
@@ -34,8 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KristofferStrube.Blazor.FileAPI" Version="0.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.20" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Blazor.FileAPI\src\KristofferStrube.Blazor.FileAPI\KristofferStrube.Blazor.FileAPI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemGetDirectoryOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemGetDirectoryOptions.cs
@@ -1,13 +1,14 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemgetdirectoryoptions">FileSystemGetDirectoryOptions browser specs</see>
-/// </summary>
-public class FileSystemGetDirectoryOptions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [JsonPropertyName("create")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Create { get; set; }
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemgetdirectoryoptions">FileSystemGetDirectoryOptions browser specs</see>
+    /// </summary>
+    public class FileSystemGetDirectoryOptions
+    {
+        [JsonPropertyName("create")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool Create { get; set; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemGetFileOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemGetFileOptions.cs
@@ -1,13 +1,14 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemgetfileoptions">FileSystemGetFileOptions browser specs</see>
-/// </summary>
-public class FileSystemGetFileOptions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [JsonPropertyName("create")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Create { get; set; }
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemgetfileoptions">FileSystemGetFileOptions browser specs</see>
+    /// </summary>
+    public class FileSystemGetFileOptions
+    {
+        [JsonPropertyName("create")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool Create { get; set; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemOptions.cs
@@ -1,18 +1,19 @@
 ﻿using System.Reflection;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public class FileSystemOptions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public const string DefaultBasePath = "./_content/";
-    public static readonly string DefaultNamespace = Assembly.GetExecutingAssembly().GetName().Name ?? "KristofferStrube.Blazor.FileSystem";
-    public static readonly string DefaultScriptPath = $"{DefaultNamespace}/{DefaultNamespace}.js";
+    public class FileSystemOptions
+    {
+        public const string DefaultBasePath = "./_content/";
+        public static readonly string DefaultNamespace = Assembly.GetExecutingAssembly().GetName().Name ?? "KristofferStrube.Blazor.FileSystem";
+        public static readonly string DefaultScriptPath = $"{DefaultNamespace}/{DefaultNamespace}.js";
 
-    public string BasePath { get; set; } = DefaultBasePath;
-    public string ScriptPath { get; set; } = DefaultScriptPath;
+        public string BasePath { get; set; } = DefaultBasePath;
+        public string ScriptPath { get; set; } = DefaultScriptPath;
 
-    public string FullScriptPath => Path.Combine(this.BasePath, this.ScriptPath);
+        public string FullScriptPath => Path.Combine(this.BasePath, this.ScriptPath);
 
-    internal static FileSystemOptions DefaultInstance = new();
+        internal static FileSystemOptions DefaultInstance = new();
 
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemRemoveOptions.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Options/FileSystemRemoveOptions.cs
@@ -1,13 +1,14 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-/// <summary>
-/// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemremoveoptions">FileSystemRemoveOptions browser specs</see>
-/// </summary>
-public class FileSystemRemoveOptions
+namespace KristofferStrube.Blazor.FileSystem
 {
-    [JsonPropertyName("recursive")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Recursive { get; set; }
+    /// <summary>
+    /// <see href="https://fs.spec.whatwg.org/#dictdef-filesystemremoveoptions">FileSystemRemoveOptions browser specs</see>
+    /// </summary>
+    public class FileSystemRemoveOptions
+    {
+        [JsonPropertyName("recursive")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool Recursive { get; set; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/Options/WriteParams.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/Options/WriteParams.cs
@@ -2,52 +2,53 @@
 using KristofferStrube.Blazor.FileSystem.Converters;
 using System.Text.Json.Serialization;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public class BlobWriteParams : BaseWriteParams
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public BlobWriteParams(WriteCommandType type)
+    public class BlobWriteParams : BaseWriteParams
     {
-        Type = type;
+        public BlobWriteParams(WriteCommandType type)
+        {
+            Type = type;
+        }
+
+        [JsonPropertyName("data")]
+        [JsonConverter(typeof(BlobConverter))]
+        public Blob? Data { get; set; }
     }
 
-    [JsonPropertyName("data")]
-    [JsonConverter(typeof(BlobConverter))]
-    public Blob? Data { get; set; }
-}
-
-public class StringWriteParams : BaseWriteParams
-{
-    public StringWriteParams(WriteCommandType type)
+    public class StringWriteParams : BaseWriteParams
     {
-        Type = type;
+        public StringWriteParams(WriteCommandType type)
+        {
+            Type = type;
+        }
+
+        [JsonPropertyName("data")]
+        public string? Data { get; set; }
     }
 
-    [JsonPropertyName("data")]
-    public string? Data { get; set; }
-}
-
-public class ByteArrayWriteParams : BaseWriteParams
-{
-    public ByteArrayWriteParams(WriteCommandType type)
+    public class ByteArrayWriteParams : BaseWriteParams
     {
-        Type = type;
+        public ByteArrayWriteParams(WriteCommandType type)
+        {
+            Type = type;
+        }
+
+        [JsonPropertyName("data")]
+        public byte[]? Data { get; set; }
     }
 
-    [JsonPropertyName("data")]
-    public byte[]? Data { get; set; }
-}
+    public abstract class BaseWriteParams
+    {
+        [JsonPropertyName("type")]
+        public WriteCommandType Type { get; init; }
 
-public abstract class BaseWriteParams
-{
-    [JsonPropertyName("type")]
-    public WriteCommandType Type { get; init; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("size")]
+        public ulong Size { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [JsonPropertyName("size")]
-    public ulong Size { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [JsonPropertyName("position")]
-    public ulong Position { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("position")]
+        public ulong Position { get; set; }
+    }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/StorageManagerService.InProcess.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/StorageManagerService.InProcess.cs
@@ -1,27 +1,28 @@
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public class StorageManagerServiceInProcess : StorageManagerService, IStorageManagerServiceInProcess
+namespace KristofferStrube.Blazor.FileSystem
 {
-    public StorageManagerServiceInProcess(IJSRuntime jSRuntime) : base(jSRuntime) { }
-
-    /// <summary>
-    /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
-    /// </summary>
-    /// <returns></returns>
-    public new async Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync()
+    public class StorageManagerServiceInProcess : StorageManagerService, IStorageManagerServiceInProcess
     {
-        return await GetOriginPrivateDirectoryAsync(FileSystemOptions.DefaultInstance);
-    }
+        public StorageManagerServiceInProcess(IJSRuntime jSRuntime) : base(jSRuntime) { }
 
-    /// <summary>
-    /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
-    /// </summary>
-    /// <returns></returns>
-    public new async Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync(FileSystemOptions options)
-    {
-        IJSInProcessObjectReference directoryHandle = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("navigator.storage.getDirectory");
-        return await FileSystemDirectoryHandleInProcess.CreateAsync(jSRuntime, directoryHandle, options);
+        /// <summary>
+        /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
+        /// </summary>
+        /// <returns></returns>
+        public new async Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync()
+        {
+            return await GetOriginPrivateDirectoryAsync(FileSystemOptions.DefaultInstance);
+        }
+
+        /// <summary>
+        /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
+        /// </summary>
+        /// <returns></returns>
+        public new async Task<FileSystemDirectoryHandleInProcess> GetOriginPrivateDirectoryAsync(FileSystemOptions options)
+        {
+            IJSInProcessObjectReference directoryHandle = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("navigator.storage.getDirectory");
+            return await FileSystemDirectoryHandleInProcess.CreateAsync(jSRuntime, directoryHandle, options);
+        }
     }
 }

--- a/src/KristofferStrube.Blazor.FileSystem/StorageManagerService.cs
+++ b/src/KristofferStrube.Blazor.FileSystem/StorageManagerService.cs
@@ -1,46 +1,46 @@
 using KristofferStrube.Blazor.FileSystem.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
-namespace KristofferStrube.Blazor.FileSystem;
-
-public class StorageManagerService : IStorageManagerService
+namespace KristofferStrube.Blazor.FileSystem
 {
-    protected readonly Lazy<Task<IJSObjectReference>> helperTask;
-    protected readonly IJSRuntime jSRuntime;
-
-    public StorageManagerService(IJSRuntime jSRuntime)
+    public class StorageManagerService : IStorageManagerService
     {
-        helperTask = new(() => jSRuntime.GetHelperAsync(FileSystemOptions.DefaultInstance));
-        this.jSRuntime = jSRuntime;
-    }
+        protected readonly Lazy<Task<IJSObjectReference>> helperTask;
+        protected readonly IJSRuntime jSRuntime;
 
-    /// <summary>
-    /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
-    /// </summary>
-    /// <returns></returns>
-    public async Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync()
-    {
-        return await GetOriginPrivateDirectoryAsync(FileSystemOptions.DefaultInstance);
-    }
-
-    /// <summary>
-    /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
-    /// </summary>
-    /// <returns></returns>
-    public async Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync(FileSystemOptions options)
-    {
-        IJSObjectReference directoryHandle = await jSRuntime.InvokeAsync<IJSObjectReference>("navigator.storage.getDirectory");
-        return new FileSystemDirectoryHandle(jSRuntime, directoryHandle, options);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (helperTask.IsValueCreated)
+        public StorageManagerService(IJSRuntime jSRuntime)
         {
-            IJSObjectReference module = await helperTask.Value;
-            await module.DisposeAsync();
+            helperTask = new(() => jSRuntime.GetHelperAsync(FileSystemOptions.DefaultInstance));
+            this.jSRuntime = jSRuntime;
         }
-        GC.SuppressFinalize(this);
+
+        /// <summary>
+        /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
+        /// </summary>
+        /// <returns></returns>
+        public async Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync()
+        {
+            return await GetOriginPrivateDirectoryAsync(FileSystemOptions.DefaultInstance);
+        }
+
+        /// <summary>
+        /// <see href="https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory">getDirectory() for StorageManager browser specs</see>
+        /// </summary>
+        /// <returns></returns>
+        public async Task<FileSystemDirectoryHandle> GetOriginPrivateDirectoryAsync(FileSystemOptions options)
+        {
+            IJSObjectReference directoryHandle = await jSRuntime.InvokeAsync<IJSObjectReference>("navigator.storage.getDirectory");
+            return new FileSystemDirectoryHandle(jSRuntime, directoryHandle, options);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (helperTask.IsValueCreated)
+            {
+                IJSObjectReference module = await helperTask.Value;
+                await module.DisposeAsync();
+            }
+            GC.SuppressFinalize(this);
+        }
     }
 }


### PR DESCRIPTION
Fix to work with the latest version of Blazor.Streams (0.4.2) WritableStream base class.

Missing a CreationOptions parameter for WritableStream constuctor.